### PR TITLE
Styling fixes: tables, content width

### DIFF
--- a/frontend/src/styles/base.scss
+++ b/frontend/src/styles/base.scss
@@ -49,11 +49,14 @@ table {
   width: 100%;
   text-align: left;
   background-color: #f8f9fa;
+  border-collapse: collapse;
+  word-wrap: break-word;
 }
 
 td {
   border-width: 0px;
-  padding: 0px 10px;
+  padding: 8px 8px;
+  font-size: 14px;
 }
 
 th {
@@ -61,11 +64,16 @@ th {
   padding: 10px;
   font-weight: bold;
   color: white;
+  white-space: nowrap;
 }
 
 tr {
   background-color: #f8f9fa;
-  border-bottom: 1px solid #cfd8dc;
+  border-top: 1px solid #cfd8dc;
+
+  td:first-of-type {
+    white-space: nowrap;
+  }
 }
 
 .img-parent {

--- a/frontend/src/styles/variables.scss
+++ b/frontend/src/styles/variables.scss
@@ -7,6 +7,6 @@ $amber: #ffa000;
 
 $shadow: rgba(0, 0, 0, 0.2);
 
-$max-content-width: 1280px;
+$max-content-width: 1080px;
 $tablet: 1400px;
 $phone: 720px;


### PR DESCRIPTION
Changes:

- Max width to 1080 (from 1280)
- Tables now have row borders
- Table headers never word wrap
- Table first column never word wraps
- More table padding
- Smaller table font size

Fixes #35 

**Before**
![image](https://user-images.githubusercontent.com/8466666/43855506-aea16034-9afa-11e8-908d-6ca6b9921cb5.png)


**After**
![image](https://user-images.githubusercontent.com/8466666/43855516-b8e05a8c-9afa-11e8-9be7-528b391e1aad.png)
