### PR TITLE
Fix project fetching, remove subprojects, unify logging

### DIFF
--- a/functions/logger.js
+++ b/functions/logger.js
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+const Logger = function() {};
+
+Logger.prototype.debug = function(tag, msg) {
+  console.log(`[${tag}] ${msg}`);
+};
+
+Logger.prototype.error = function(tag, msg, e) {
+  console.warn(`[${tag}] ERROR: ${msg}`, e);
+};
+
+module.exports = new Logger();


### PR DESCRIPTION
This fixes #1 

Also fixes a bug where having `pages: []` would trigger a strange error due to an empty Firestore WriteBatch.

Also unifies logging format.