### PR TITLE
fix(frontend): Link to add project should use template

### DIFF
--- a/frontend/src/components/Homepage/template.html
+++ b/frontend/src/components/Homepage/template.html
@@ -21,7 +21,7 @@
                 On <a href="/">firebaseopensource.com</a> you can discover all of the tools you need to build a great app.
                 <br /><br />
                 Is there a great open source Firebase project that should be included here? 
-                <a target="_blank" href="https://github.com/firebase/firebaseopensource.com/issues/new">Let us know!</a>
+                <a target="_blank" href="https://github.com/firebase/firebaseopensource.com/issues/new?template=new_project.md">Let us know!</a>
               </span>
             </div>
           </div>


### PR DESCRIPTION
The link to add new projects on landing page ("Is there a great open source Firebase project that should be included here? Let us know!") should point to new issue with template: https://github.com/firebase/firebaseopensource.com/issues/new?template=new_project.md