### PR TITLE
fix: "Add Project" link

### DIFF
--- a/frontend/src/components/Projects/index.ts
+++ b/frontend/src/components/Projects/index.ts
@@ -54,7 +54,7 @@ const OSS_SIDEBAR = new SidebarSection("Open Source", [
   new SelectableLink("Home", "/"),
   new SelectableLink(
     "Add Project",
-    "https://github.com/firebase/firebaseopensource.com/issues/new/choose",
+    "https://github.com/firebase/firebaseopensource.com/issues/new?template=new_project.md",
     false,
     true
   )


### PR DESCRIPTION
"Add Project" link (under "Open Source" in left nav on project 1-up page) should point to new issue form with `template=new_project.md`.