### PR TITLE
refactor: unset firestore setting `timestampsInSnapshots`

### DIFF
--- a/functions/src/project.ts
+++ b/functions/src/project.ts
@@ -38,7 +38,6 @@ try {
 }
 
 const db = admin.firestore();
-db.settings({ timestampsInSnapshots: true });
 
 export class Project {
   params: GetParams;


### PR DESCRIPTION
Starting in version [5.8.0](https://firebase.google.com/support/release-notes/js#cloud-firestore_34), firestore's `timestampsInSnapshots` is set to `true` by default, so we no longer need to set it manually in our code.