### PR TITLE
Renamed lupas::nuxt-fire

### DIFF
--- a/config/additional_projects.json
+++ b/config/additional_projects.json
@@ -23,7 +23,7 @@
     "anishkny::integrify",
     "kreait::firebase-php",
     "geofirestore::geofirestore-js",
-    "lupas::nuxt-fire",
+    "nuxt-community::firebase-module",
     "dantothefuture::svarog",
     "flamelink::flamelink-js-sdk",
     "FirebaseExtended::flutterfire",

--- a/frontend/routes.json
+++ b/frontend/routes.json
@@ -106,7 +106,7 @@
     "projects/jsayol/firesql",
     "projects/jsayol/vscode-firebase-explorer",
     "projects/kreait/firebase-php",
-    "projects/lupas/nuxt-fire",
+    "projects/nuxt-community/firebase-module",
     "projects/oddbit/tanam",
     "projects/patilshreyas/firebaserecyclerpagination",
     "projects/peterhdd/firebase-firestore-snippets",


### PR DESCRIPTION
Renamed `lupas/nuxt-fire` to `nuxt-community/firebase` because the repo has moved to the official nuxt-community team repo:

Old: https://github.com/lupas/nuxt-fire
New: https://github.com/nuxt-community/firebase-module
