### PR TITLE
fix: moved code-prettify from app.html to project component

### DIFF
--- a/frontend/app.html
+++ b/frontend/app.html
@@ -9,8 +9,7 @@
     <link rel="icon" href="/logo-small.png" />
 
     <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Roboto:300,400,400italic,500,500italic,700,700italic|Roboto+Mono:400,500,700|Material+Icons" />
-
-    <script src="https://cdn.jsdelivr.net/gh/google/code-prettify@master/loader/run_prettify.js" defer></script>
+    
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-110728272-1"></script>
  
     <script>

--- a/frontend/pages/projects/_org/_repo/_.vue
+++ b/frontend/pages/projects/_org/_repo/_.vue
@@ -82,6 +82,9 @@ function getCleanParams (params: ProjectRouteParams) {
           property: 'og:title',
           content: this.pageTitle
         }
+      ],
+      script: [
+        { src: 'https://cdn.jsdelivr.net/gh/google/code-prettify@master/loader/run_prettify.js', defer: true }
       ]
     }
     return head


### PR DESCRIPTION
@samtstern 

This seems to do it. https://github.com/firebase/firebaseopensource.com/issues/155

- Moved code-prettify from app.html to project component

So everytime the project component(page) gets loaded, this script also runs. And it doesn't get loaded on all the other pages, so there's even some performance benefit to this approach.