### PR TITLE
fix(badges): Handle awesome.re badges

### DIFF
--- a/functions/src/content.ts
+++ b/functions/src/content.ts
@@ -176,7 +176,8 @@ export class Content {
         "sonarcloud.io",
         "codecov.io",
         "release-notes.com",
-        /github\.com\/.*\/workflows\/.*\.svg/
+        /github\.com\/.*\/workflows\/.*\.svg/,
+        "awesome.re"
       ];
 
       const isBadge = badgePatterns.some(pattern => {


### PR DESCRIPTION
This badge is off-kilter: [![Mentioned in Awesome Firebase](https://awesome.re/mentioned-badge.svg)](https://github.com/jthegedus/awesome-firebase)

<img width="1552" alt="Screen Shot 2020-12-08 at 8 53 31 AM" src="https://user-images.githubusercontent.com/357499/101515165-ea7ada80-3932-11eb-94de-b0ca8e764b2e.png">
