### PR TITLE
Update repository of Firestore Extensions

### DIFF
--- a/config/additional_projects.json
+++ b/config/additional_projects.json
@@ -56,6 +56,6 @@
     "octabytes::fireo",
     "Waddah-JD::moleculer-db-firebase",
     "yarnaimo::fireschema",
-    "ridedott::firestore-extensions"
+    "merlinnot::firestore-extensions"
   ]
 }


### PR DESCRIPTION
My team decided it would be better to host the repository under my namespace for long-term support, so we moved it.