### PR TITLE
Remove FirebaseExtended/flutterfire from additional_projects.json

### DIFF
--- a/config/additional_projects.json
+++ b/config/additional_projects.json
@@ -32,7 +32,6 @@
     "nuxt-community::firebase-module",
     "dantothefuture::svarog",
     "flamelink::flamelink-js-sdk",
-    "FirebaseExtended::flutterfire",
     "MichaelRCruz::ioa",
     "FirebaseExtended::reactfire",
     "IjzerenHein::firestorter",


### PR DESCRIPTION
Since the repo moved from FirebaseExtended/flutterfire to firebase/flutterfire, having it in additional_projects.json duplicates it in the projects list:

<img width="1600" alt="image" src="https://github.com/user-attachments/assets/ed9ceb6f-32ba-46e6-bb83-06061c4b860b" />

---

Internal bug: [b/548280755](http://b/548280755)